### PR TITLE
add gray ramps for color themes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@
 
 #include "FLE/Fle_Colors.hpp"
 
-static char* ikona_xpm[] = {
+static const char* ikona_xpm[] = {
 "16 16 8 1",
 " 	c None",
 ".	c #000000",


### PR DESCRIPTION
Hello @CyprinusCarpio 

This PR adds gray ramps and color muting to the current color themes.
Without the gray ramps, FLTK defaults to brighter shadows with certain schemes (especially the oxy and gtk schemes).

For example the dark2 theme, with gray ramps:
![image](https://github.com/user-attachments/assets/961f2acc-d23d-47b0-92e7-0e594c5b693e)

without:
![image](https://github.com/user-attachments/assets/f7e20fc4-7e64-4943-8e3b-9f3711dfd249)

